### PR TITLE
Improve Telegram updates

### DIFF
--- a/.github/workflows/daily_sync.yml
+++ b/.github/workflows/daily_sync.yml
@@ -1,0 +1,41 @@
+name: Daily sync
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Update from upstream
+        run: |
+          git remote add upstream https://github.com/rust-lang/this-week-in-rust.git
+          git fetch upstream
+          git merge --ff-only upstream/main
+
+      - name: Push changes
+        run: |
+          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:main
+
+      - name: Install Python dependencies
+        uses: py-actions/py-dependency-install@9c419aa98bfb42280bdae2b0a736befd9b01e3b1 # v4
+        with:
+          path: "tools/requirements.txt"
+          update-pip: "false"
+          update-setuptools: "false"
+          update-wheel: "false"
+
+      - name: Send latest post to Telegram
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          latest_post=$(ls content/*-this-week-in-rust*.md | sort | tail -n1)
+          python3 tools/send_telegram.py "$latest_post"
+

--- a/README.md
+++ b/README.md
@@ -211,3 +211,15 @@ variable to `True`.
   ```
 * View the email newsletter formatting of specific posts at
   http://localhost:8000/blog/{YEAR}/{MONTH}/{DAY}/{ISSUE}/
+
+## Workflow Secrets
+
+The daily synchronization workflow requires the following repository secrets:
+
+- `TELEGRAM_BOT_TOKEN` – token of the bot used to send Telegram messages.
+- `TELEGRAM_CHAT_ID` – ID of the chat that should receive updates.
+
+The workflow sends the newest post through `tools/send_telegram.py`,
+which converts Markdown to HTML and uses Telegram's `parse_mode=HTML` for
+correct formatting.
+

--- a/tools/send_telegram.py
+++ b/tools/send_telegram.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+"""Send a Markdown file to Telegram using HTML parse mode."""
+
+import os
+import sys
+import markdown
+import urllib.parse
+import urllib.request
+
+
+def send_html(chat_id: str, token: str, html: str) -> None:
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    data = urllib.parse.urlencode({
+        "chat_id": chat_id,
+        "parse_mode": "HTML",
+        "text": html,
+    }).encode()
+    req = urllib.request.Request(url, data=data)
+    with urllib.request.urlopen(req) as resp:
+        resp.read()
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: send_telegram.py <markdown_file>")
+        return 1
+
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        md_text = f.read()
+
+    html_text = markdown.markdown(md_text)
+
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    chat_id = os.getenv("TELEGRAM_CHAT_ID")
+    if not token or not chat_id:
+        sys.stderr.write("Environment variables TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID must be set\n")
+        return 1
+
+    send_html(chat_id, token, html_text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- add Python utility to convert markdown to HTML and send it to Telegram
- update daily sync workflow to call the script
- describe the new HTML send step in the docs

## Testing
- `python3 tools/inspect_markdown.py --num-recent 1`
- `python3 tools/inspect_links.py --num-warn 1`

------
https://chatgpt.com/codex/tasks/task_e_6851ad35a6a48331bc3dfcacb78f8088