### PR TITLE
Fix upstream sync branch

### DIFF
--- a/.github/workflows/daily_sync.yml
+++ b/.github/workflows/daily_sync.yml
@@ -17,11 +17,11 @@ jobs:
         run: |
           git remote add upstream https://github.com/rust-lang/this-week-in-rust.git
           git fetch upstream
-          git merge --ff-only upstream/main
+          git merge --ff-only upstream/master
 
       - name: Push changes
         run: |
-          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:main
+          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:master
 
       - name: Install Python dependencies
         uses: py-actions/py-dependency-install@9c419aa98bfb42280bdae2b0a736befd9b01e3b1 # v4


### PR DESCRIPTION
## Summary
- correct daily sync workflow to merge `upstream/master`

## Testing
- `python3 tools/inspect_links.py --num-warn 5`
- `python3 tools/inspect_markdown.py --num-recent 5`


------
https://chatgpt.com/codex/tasks/task_e_6851c845a3888331920489cc6fc53635